### PR TITLE
Change link of GetStarted from # to reference documents.

### DIFF
--- a/resources/default/src/pages/index.js
+++ b/resources/default/src/pages/index.js
@@ -71,7 +71,7 @@ function Home() {
                 'button button--outline button--secondary button--lg',
                 styles.getStarted,
               )}
-              to={useBaseUrl('#')}>
+              to={useBaseUrl('docs/reference/')}>
               Get Started
             </Link>
           </div>


### PR DESCRIPTION
The reason for the change link of GetStarted is as below.

* For the API, GetStarted is the documentation.