### PR TITLE
Upgrade to docusaurus@2.0.0-beta.8

### DIFF
--- a/docs/docs/definition.md
+++ b/docs/docs/definition.md
@@ -4,7 +4,7 @@ title: Definition
 ---
 
 ### Definition
-Prepare the OpenAPI file to create the document.  
+Prepare the OpenAPI file to create the document.
 This time we will use example/openapi.json as an example.
 
 #### example/openapi.json
@@ -204,3 +204,16 @@ This time we will use example/openapi.json as an example.
   }
 }
 ```
+
+### Precautions
+
+#### Path segment starting with underscore
+
+Note that if the path segment provides an API that starts with underscore,
+for example `_search`, it will be excluded by the default docusaurus behavior.
+
+
+As mentioned in [the pull request](https://github.com/facebook/docusaurus/pull/5173),
+if you are exposing an API that contains a path segment that starts with underscore,
+you can get the expected behavior by removing the prefix rule that starts with underscore
+from the exclude configuration.

--- a/docs/docs/definition.md
+++ b/docs/docs/definition.md
@@ -207,13 +207,11 @@ This time we will use example/openapi.json as an example.
 
 ### Precautions
 
-#### Path segment starting with underscore
+#### Path segment starting with an underscore
 
-Note that if the path segment provides an API that starts with underscore,
-for example `_search`, it will be excluded by the default docusaurus behavior.
-
+Note that if the path segment provides an API that starts with an underscore,
+for example, `_search` will be excluded by the default docusaurus behavior.
 
 As mentioned in [the pull request](https://github.com/facebook/docusaurus/pull/5173),
-if you are exposing an API that contains a path segment that starts with underscore,
-you can get the expected behavior by removing the prefix rule that starts with underscore
-from the exclude configuration.
+if you are exposing an API that contains a path segment that starts with an underscore,
+you can get the expected behavior by removing the prefix rule that starts with an underscore from the exclude configuration.

--- a/resources/default/package.json
+++ b/resources/default/package.json
@@ -13,12 +13,11 @@
   },
   "dependencies": {
     "@apidevtools/swagger-parser": "^10.0.2",
-    "@docusaurus/core": "2.0.0-alpha.71",
-    "@docusaurus/preset-classic": "2.0.0-alpha.71",
+    "@docusaurus/core": "2.0.0-beta.8",
+    "@docusaurus/preset-classic": "2.0.0-beta.8",
     "@mdx-js/react": "^1.6.21",
     "clsx": "^1.1.1",
     "react": "^17.0.1",
-    "react-async": "^10.0.1",
     "react-dom": "^17.0.1"
   },
   "browserslist": {

--- a/resources/default/src/formadocs/index.js
+++ b/resources/default/src/formadocs/index.js
@@ -1,18 +1,10 @@
 import React from 'react';
+import clsx from 'clsx';
 import OpenAPI from './openapi.json';
 
-import SwaggerParser from "@apidevtools/swagger-parser";
-import { useAsync } from "react-async"
-import clsx from 'clsx';
-
-const parser = async ({api}) => {
-  return await SwaggerParser.parse(api)
-}
-
 export function FormadocsTag ({endpoint, method}) {
-  const {data} = useAsync({ promiseFn: parser, api: OpenAPI});
-  if (data) {
-    const resource = data.paths[endpoint][method];
+  if (OpenAPI) {
+    const resource = OpenAPI.paths[endpoint][method];
     if (resource.tags) {
       return (
         <div>
@@ -50,9 +42,8 @@ export function FormadocsMethod ({endpoint, method}) {
 }
 
 export function FormadocsEndpoint ({endpoint, method}) {
-  const {data} = useAsync({ promiseFn: parser, api: OpenAPI});
-  if (data) {
-    const url = (data.servers) ? data.servers[0].url : '';
+  if (OpenAPI) {
+    const url = (OpenAPI.servers) ? OpenAPI.servers[0].url : '';
     return (
       <div>
         {`${url}${endpoint}`}
@@ -63,9 +54,8 @@ export function FormadocsEndpoint ({endpoint, method}) {
 }
 
 export function FormadocsParameters ({endpoint, method}) {
-  const {data} = useAsync({ promiseFn: parser, api: OpenAPI});
-  if (data) {
-    const resource = data.paths[endpoint][method];
+  if (OpenAPI) {
+    const resource = OpenAPI.paths[endpoint][method];
     if (resource.parameters) {
       return (
         <table>
@@ -97,9 +87,8 @@ export function FormadocsParameters ({endpoint, method}) {
 }
 
 export function FormadocsRequestBody ({endpoint, method}) {
-  const {data} = useAsync({ promiseFn: parser, api: OpenAPI});
-  if (data) {
-    const resource = data.paths[endpoint][method];
+  if (OpenAPI) {
+    const resource = OpenAPI.paths[endpoint][method];
     if (resource.requestBody) {
       return (
         <div>
@@ -118,9 +107,8 @@ export function FormadocsRequestBody ({endpoint, method}) {
 }
 
 export function FormadocsResponses ({endpoint, method}) {
-  const {data} = useAsync({ promiseFn: parser, api: OpenAPI});
-  if (data) {
-    const resource = data.paths[endpoint][method];
+  if (OpenAPI) {
+    const resource = OpenAPI.paths[endpoint][method];
     if (resource.responses) {
       return (
         <table>


### PR DESCRIPTION
Upgrade docusaurus version to 2.0.0-beta8.

### Remarks

Removed some unnecessary code to support Webpack 5, which docusaurus depends on internally.

### TODO

- [x] Describe the document about how to handle files starting with `_`.