### PR TITLE
Add example of what to do when a path contains underscores.

### DIFF
--- a/docs/docs/definition.md
+++ b/docs/docs/definition.md
@@ -227,10 +227,10 @@ module.exports = {
   presets: [
     [
       {
-      docs: {
-        exclude: [
-              '**/*.test.{js,jsx,ts,tsx}',
-              '**/__tests__/**',
+        docs: {
+          exclude: [
+            '**/*.test.{js,jsx,ts,tsx}',
+            '**/__tests__/**',
           ]
         },
       },

--- a/docs/docs/definition.md
+++ b/docs/docs/definition.md
@@ -215,3 +215,26 @@ for example, `_search` will be excluded by the default docusaurus behavior.
 As mentioned in [the pull request](https://github.com/facebook/docusaurus/pull/5173),
 if you are exposing an API that contains a path segment that starts with an underscore,
 you can get the expected behavior by removing the prefix rule that starts with an underscore from the exclude configuration.
+
+##### For example
+
+The following shows the insertion position of the corresponding example.
+
+* docusaurus.config.js
+
+```javascript
+module.exports = {
+  presets: [
+    [
+      {
+      docs: {
+        exclude: [
+              '**/*.test.{js,jsx,ts,tsx}',
+              '**/__tests__/**',
+          ]
+        },
+      },
+    ],
+  ],
+};
+```


### PR DESCRIPTION
It was difficult to understand how to handle cases where underscores are included in the path.
Therefore, examples of how to handle this have been added to the document.