### PR TITLE
Support docusaurus 2.1

### DIFF
--- a/resources/default/package.json
+++ b/resources/default/package.json
@@ -13,12 +13,15 @@
   },
   "dependencies": {
     "@apidevtools/swagger-parser": "^10.0.2",
-    "@docusaurus/core": "2.0.0-beta.8",
-    "@docusaurus/preset-classic": "2.0.0-beta.8",
-    "@mdx-js/react": "^1.6.21",
-    "clsx": "^1.1.1",
-    "react": "^17.0.1",
-    "react-dom": "^17.0.1"
+    "@docusaurus/core": "2.1.0",
+    "@docusaurus/preset-classic": "2.1.0",
+    "@mdx-js/react": "^1.6.22",
+    "clsx": "^1.2.1",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2"
+  },
+  "devDependencies": {
+    "@docusaurus/module-type-aliases": "2.1.0"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
Support docusaurus 2.1.

The version of the dependent package was initialized with `npx create-docusaurus@latest my-website classic` at this time.

It is the same as the package dependencies.

```json
{
  ...
  "dependencies": {
    "@docusaurus/core": "2.1.0",
    "@docusaurus/preset-classic": "2.1.0",
    "@mdx-js/react": "^1.6.22",
    "clsx": "^1.2.1",
    "prism-react-renderer": "^1.3.5",
    "react": "^17.0.2",
    "react-dom": "^17.0.2"
  },
  "devDependencies": {
    "@docusaurus/module-type-aliases": "2.1.0"
  },
  ...
}
```